### PR TITLE
Add animation options in initializer + compatibility with iOS 9 devices

### DIFF
--- a/PullToDismissTransition.podspec
+++ b/PullToDismissTransition.podspec
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
   s.source_files     = 'PullToDismissTransition.swift', 'PullToDismissable.swift'
   s.social_media_url = 'https://twitter.com/benguild'
 
-  s.platform     = :ios, '10.0'
+  s.platform     = :ios, '9.0'
   s.requires_arc = true
-  s.swift_version = '4.1'
+  s.swift_version = '4.2'
 
 end

--- a/PullToDismissTransition.podspec
+++ b/PullToDismissTransition.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PullToDismissTransition"
-  s.version          = "0.7.9"
+  s.version          = "0.7.10"
   s.homepage         = "https://github.com/benguild/PullToDismissTransition"
   s.summary          = "Uses `UIPercentDrivenInteractiveTransition` and `UIViewControllerAnimatedTransitioning` to quickly implement nice “pull-to-dismiss” interactions on modal view controller(s). — Also handles `UIScrollView` bounce toggling dynamically when necessary. "
   s.license          = 'MIT'

--- a/PullToDismissTransition.swift
+++ b/PullToDismissTransition.swift
@@ -177,7 +177,7 @@ public class PullToDismissTransition: UIPercentDrivenInteractiveTransition {
     ) -> Bool {
         return !recentScrollIsBlockingTransition &&
             velocity.y > Const.velocityBeginThreshold &&
-            velocity.y > fabs(velocity.x) &&
+            velocity.y > abs(velocity.x) &&
             (permitWhenNotAtRootViewController || isAtRootViewController()) &&
             (monitoredScrollView?.contentOffset.y ?? 0) <= 0 &&
             (delegate?.canBeginPullToDismiss(on: viewController) ?? true)
@@ -359,12 +359,14 @@ extension PullToDismissTransition: UIViewControllerAnimatedTransitioning {
                 shouldRoundCorners = true
             }
 
-            if shouldRoundCorners {
-                scalingView.layer.masksToBounds = true
+            if #available(iOS 10.0, *) {
+                if shouldRoundCorners {
+                    scalingView.layer.masksToBounds = true
 
-                UIViewPropertyAnimator(duration: Const.scalingViewCornerRadiusToggleDuration, curve: .easeIn) {
-                    scalingView.layer.cornerRadius = Const.scalingViewCornerRadius
-                }.startAnimation()
+                    UIViewPropertyAnimator(duration: Const.scalingViewCornerRadiusToggleDuration, curve: .easeIn) {
+                        scalingView.layer.cornerRadius = Const.scalingViewCornerRadius
+                        }.startAnimation()
+                }
             }
         }
     }
@@ -375,13 +377,16 @@ extension PullToDismissTransition: UIViewControllerAnimatedTransitioning {
         completionHandler: (() -> Void)? = nil
     ) {
         if transitionContext.transitionWasCancelled, let scalingView = scalingView {
-            if scalingView.layer.cornerRadius > 0 {
-                viewController.view.layer.cornerRadius = scalingView.layer.cornerRadius
-                viewController.view.layer.masksToBounds = true
+            
+            if #available(iOS 10.0, *) {
+                if scalingView.layer.cornerRadius > 0 {
+                    viewController.view.layer.cornerRadius = scalingView.layer.cornerRadius
+                    viewController.view.layer.masksToBounds = true
 
-                UIViewPropertyAnimator(duration: Const.scalingViewCornerRadiusToggleDuration, curve: .easeIn) {
-                    viewController.view.layer.cornerRadius = 0
-                }.startAnimation()
+                    UIViewPropertyAnimator(duration: Const.scalingViewCornerRadiusToggleDuration, curve: .easeIn) {
+                        viewController.view.layer.cornerRadius = 0
+                        }.startAnimation()
+                }
             }
 
             viewController.view.isHidden = false

--- a/PullToDismissTransition.swift
+++ b/PullToDismissTransition.swift
@@ -55,6 +55,7 @@ public class PullToDismissTransition: UIPercentDrivenInteractiveTransition {
     }
 
     public let transitionType: PullToDismissTransitionType
+    public let animationOptions: UIView.AnimationOptions
     private(set) weak var viewController: UIViewController?
 
     private(set) weak var monitoredScrollView: UIScrollView?
@@ -88,9 +89,10 @@ public class PullToDismissTransition: UIPercentDrivenInteractiveTransition {
         transitionDelegateObservation?.invalidate()
     }
 
-    public init(viewController: UIViewController, transitionType: PullToDismissTransitionType = .slideStatic) {
+    public init(viewController: UIViewController, transitionType: PullToDismissTransitionType = .slideStatic, animationOptions: UIView.AnimationOptions = [.curveLinear]) {
         self.transitionType = transitionType
         self.viewController = viewController
+        self.animationOptions = animationOptions
 
         super.init()
     }
@@ -440,7 +442,7 @@ extension PullToDismissTransition: UIViewControllerAnimatedTransitioning {
         UIView.animate(
             withDuration: transitionDuration(using: transitionContext),
             delay: 0,
-            options: .curveEaseOut,
+            options: animationOptions,
             animations: { [weak self] in
                 guard let strongSelf = self else { return }
 


### PR DESCRIPTION
Hi, thanks for your repo, here are some modifications to allow older devices to work with the lib as well as a new parameter in initializer method for the animation options (default to .curveLinear, it feels less buggy when you scroll).