### PR TITLE
[Fix] The "jumping" bug

### DIFF
--- a/PullToDismissTransition.swift
+++ b/PullToDismissTransition.swift
@@ -222,13 +222,10 @@ public class PullToDismissTransition: UIPercentDrivenInteractiveTransition {
                     (translation.y - transitionIsActiveFromTranslationPoint.y) / max(1, view.bounds.size.height)
                 ))
 
-                if progress == 0 {
-                    stopPullToDismiss(on: viewController, finished: false)
-                    break
+                if progress > 0 {
+                    transitionProgress = progress
+                    update(progress)
                 }
-
-                transitionProgress = progress
-                update(progress)
             } else if canBeginPullToDismiss(velocity: velocity, on: viewController) {
                 transitionIsActiveFromTranslationPoint = translation
 


### PR DESCRIPTION
As noted in the #2, `stopPullToDismiss` is called twice (when `progress` is zero, but also because `handlePan` is called again with `panGestureRecognizer.state` equal to `.ended`) and so `UIPercentDrivenInteractiveTransition.cancel()` is called twice.

Fixes #2